### PR TITLE
writelines encoding='utf-8'

### DIFF
--- a/gsil/engine.py
+++ b/gsil/engine.py
@@ -25,7 +25,7 @@ from .log import logger
 
 regex_mail = r"([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)"
 regex_host = r"@([a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)"
-regex_pass = r"(pass|password)"
+regex_pass = r"(pass|password|pwd)"
 regex_title = r"<title>(.*)<\/title>"
 regex_ip = r"^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))$"
 

--- a/gsil/process.py
+++ b/gsil/process.py
@@ -75,7 +75,7 @@ class Process(object):
         :param data:
         :return:
         """
-        with open(os.path.join(Config().data_path, sha), 'w+') as f:
+        with open(os.path.join(Config().data_path, sha), 'w+', encoding='utf-8') as f:
             f.writelines(data)
         return True
 


### PR DESCRIPTION
2018-01-30 12:00:58,107 [GSIL] [INFO] ["some_company.com"] [49/21611] Processing is complete, the next one!
2018-01-30 12:00:58,108 [GSIL] [INFO] Process count: 38
Traceback (most recent call last):
  File "/Volumes/XXXX/Develop/gsil/gsil/__init__.py", line 37, in search
    return Engine(token=token).search(rule)
  File "/Volumes/XXXX/Develop/gsil/gsil/engine.py", line 210, in search
    Process(self.result, self.rule_object).process()
  File "/Volumes/XXXX/Develop/gsil/gsil/process.py", line 36, in process
    ret_mail = self._send_mail(maybe_mistake)
  File "/Volumes/XXXX/Develop/gsil/gsil/process.py", line 66, in _send_mail
    self._save_file(v['hash'], v['code'])
  File "/Volumes/XXXX/Develop/gsil/gsil/process.py", line 79, in _save_file
    f.writelines(data)
UnicodeEncodeError: 'ascii' codec can't encode character '\u9879' in position 0: ordinal not in range(128)