### PR TITLE
 修复设置了 465 ssl 端口后，发邮件报错的问题

### DIFF
--- a/gsil/notification.py
+++ b/gsil/notification.py
@@ -53,9 +53,12 @@ class Notification(object):
         msg.attach(text)
 
         try:
-            s = smtplib.SMTP(get('mail', 'host'), get('mail', 'port'))
-            s.ehlo()
-            s.starttls()
+            if port == '465':
+                s = smtplib.SMTP_SSL(host, port)
+            else:
+                s = smtplib.SMTP(host, port)
+                s.ehlo()
+                s.starttls()
             s.ehlo()
             s.login(mail, get('mail', 'password'))
             s.sendmail(mail, self.to.split(','), msg.as_string())

--- a/gsil/notification.py
+++ b/gsil/notification.py
@@ -51,6 +51,8 @@ class Notification(object):
 
         text = MIMEText(html, 'html', 'utf-8')
         msg.attach(text)
+        host = get('mail', 'host').strip()
+        port = get('mail', 'port').strip()
 
         try:
             if port == '465':


### PR DESCRIPTION
比如使用腾讯企业邮，端口 465 后，会报 ：

> smtplib.SMTPServerDisconnected: Connection unexpectedly closed

这个 pr 增加对 465 ssl 的支持。