### PR TITLE
降低误报

### DIFF
--- a/gsil/config.py
+++ b/gsil/config.py
@@ -91,6 +91,7 @@ exclude_codes_rules = [
     r'(\]\()',
     r'(npm\.taobao\.org)',
     r'(HOST-SUFFIX)|(DOMAIN-SUFFIX)',
+    r'((\.(com|net|cn|co|org)[\s\S]*){4,})',
 ]
 
 public_mail_services = [


### PR DESCRIPTION
除去存在很多域名列表的误报，如
```
0.0.0.0 adorika.net
0.0.0.0 adotmob.com
0.0.0.0 adotsolution.com
0.0.0.0 adotube.com
0.0.0.0 adpdx.com
0.0.0.0 ad.period-calendar.com
0.0.0.0 adpixo.com
```