### PR TITLE
fix sslCertVerificationError

### DIFF
--- a/gsil.py
+++ b/gsil.py
@@ -17,8 +17,11 @@
 """
 import sys
 import traceback
+import ssl
+
 from gsil import gsil
 from gsil.notification import Notification
+ssl._create_default_https_context = ssl._create_unverified_context
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
ssl报错修复
urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1056)>
